### PR TITLE
Allow fetch the record whose `SName` is empty

### DIFF
--- a/dozens/record.go
+++ b/dozens/record.go
@@ -89,8 +89,14 @@ func (c *Client) fetchRecord(req *http.Request, d *Domain, target *Record) (*Rec
 	if err != nil {
 		return nil, err
 	}
+
+	fqname := target.SName + "." + d.Name
+	if target.SName == "" {
+		fqname = d.Name
+	}
+
 	for _, e := range list {
-		if e.FQName == (target.SName+"."+d.Name) && e.Type == target.Type {
+		if e.FQName == fqname && e.Type == target.Type {
 			return e, nil
 		}
 	}


### PR DESCRIPTION
## Motivation

Example:

``` go
package main

import (
    "log"
    "net/http"

    "github.com/takebayashi/go-dozens/dozens"
)

func main() {
    client, _ := dozens.NewClient(&http.Client{}, "user", "key")
    domain, _ := client.GetDomain("gongo.org")

    record := &dozens.Record{SName: "", Type: "CNAME", Prio: "", Content: "example.com", Ttl: "7200"}
    record, err = client.AddRecord(domain, record)
    if err != nil {
        log.Fatalf("AddRecord: %s\n", err)
    }
}
```

When run this code with current master 9b2918a705601c8eed211f97fb43feaa528812fe : 

```
2015/07/03 23:03:17 AddRecord: record not found
exit status 1
```

But,  record of registration has been successful.

![2015-07-03 23 07 53](https://cloud.githubusercontent.com/assets/124713/8500568/5e3d1f3c-21d8-11e5-996c-cb7dda0f93d3.png)

This problem only occur when `name` is empty.
